### PR TITLE
test: split monolithic palindrome tests into focused unittest methods

### DIFF
--- a/tests/test_palindrome_check_new.py
+++ b/tests/test_palindrome_check_new.py
@@ -2,19 +2,28 @@ import unittest
 
 class TestPalindromeCheck(unittest.TestCase):
 
-    def test_is_palindrome(self):
+    def test_palindromic_simple_words(self):
         from palindrome_check import is_palindrome
-        self.assertTrue(is_palindrome('racecar'))
-        self.assertTrue(is_palindrome('level'))
-        self.assertFalse(is_palindrome('hello'))
-        # Edge cases
-        self.assertTrue(is_palindrome(''))  # empty string
-        self.assertTrue(is_palindrome('a'))  # single character
-        self.assertTrue(is_palindrome('A man, a plan, a canal: Panama'))  # phrase with punctuation
-        self.assertFalse(is_palindrome('not a palindrome'))  # non-palindromic phrase
-        self.assertTrue(is_palindrome('racecar'))
-        self.assertTrue(is_palindrome('level'))
-        self.assertFalse(is_palindrome('hello'))
+        for word in ["racecar", "level"]:
+            with self.subTest(word=word):
+                self.assertTrue(is_palindrome(word))
+
+    def test_non_palindromic_words(self):
+        from palindrome_check import is_palindrome
+        for word in ["hello", "not a palindrome"]:
+            with self.subTest(word=word):
+                self.assertFalse(is_palindrome(word))
+
+    def test_edge_cases(self):
+        from palindrome_check import is_palindrome
+        cases_true = [
+            "",  # empty string
+            "a",  # single character
+            "A man, a plan, a canal: Panama",  # punctuation and casing
+        ]
+        for s in cases_true:
+            with self.subTest(value=s):
+                self.assertTrue(is_palindrome(s))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Summary:
- Refactors tests/test_palindrome_check_new.py by splitting a single monolithic test method into three focused unittest methods using subTest for per-case diagnostics.
- Removes duplicated assertions and groups positive, negative, and edge cases separately.

Why:
- Improve readability, maintainability, and test failure diagnostics.
- Preserve unittest discovery to align with Dockerfile.test configuration.

Changes:
- test_is_palindrome →
  - test_palindromic_simple_words
  - test_non_palindromic_words
  - test_edge_cases

Verification:
- Ran tests in Docker container via Dockerfile.test; all tests pass:
  - Ran 3 tests in ~0.002s, OK.

Acceptance Criteria Mapping:
- Logical grouping and naming: done.
- No hidden shared state: each test imports function locally; cases isolated via subTest.
- All tests pass locally: confirmed in Docker run.
- Single feature branch and single PR: fix/refactor-tests-split-functions.
