### PR TITLE
feat(text_utils): add Levenshtein edit_distance with tests

### DIFF
--- a/tests/test_edit_distance.py
+++ b/tests/test_edit_distance.py
@@ -1,0 +1,50 @@
+import unittest
+
+
+class TestEditDistance(unittest.TestCase):
+    def test_empty_strings(self):
+        from text_utils import edit_distance
+        self.assertEqual(edit_distance("", ""), 0)
+
+    def test_empty_and_nonempty(self):
+        from text_utils import edit_distance
+        self.assertEqual(edit_distance("", "abc"), 3)
+        self.assertEqual(edit_distance("abc", ""), 3)
+
+    def test_identical_strings(self):
+        from text_utils import edit_distance
+        self.assertEqual(edit_distance("abc", "abc"), 0)
+
+    def test_substitution(self):
+        from text_utils import edit_distance
+        self.assertEqual(edit_distance("abc", "axc"), 1)
+
+    def test_insertion(self):
+        from text_utils import edit_distance
+        self.assertEqual(edit_distance("abc", "abxc"), 1)
+
+    def test_deletion(self):
+        from text_utils import edit_distance
+        self.assertEqual(edit_distance("abxc", "abc"), 1)
+
+    def test_mixed_operations(self):
+        from text_utils import edit_distance
+        # classic example
+        self.assertEqual(edit_distance("kitten", "sitting"), 3)
+        # another known pair
+        self.assertEqual(edit_distance("flaw", "lawn"), 2)
+
+    def test_unicode(self):
+        from text_utils import edit_distance
+        self.assertEqual(edit_distance("😀", "😃"), 1)
+        self.assertEqual(edit_distance("café", "cafe"), 1)
+        self.assertEqual(edit_distance("mañana", "manana"), 1)
+
+    def test_asymmetric_lengths(self):
+        from text_utils import edit_distance
+        self.assertEqual(edit_distance("a", "aaaaa"), 4)
+        self.assertEqual(edit_distance("aaaaa", "a"), 4)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_text_utils.py
+++ b/tests/test_text_utils.py
@@ -1,0 +1,48 @@
+import unittest
+
+
+class TestMostFrequentChar(unittest.TestCase):
+    def test_typical(self):
+        from text_utils import most_frequent_char
+        self.assertEqual(most_frequent_char("abca"), ("a", 2))
+
+    def test_single_character(self):
+        from text_utils import most_frequent_char
+        self.assertEqual(most_frequent_char("x"), ("x", 1))
+
+    def test_repeated_characters(self):
+        from text_utils import most_frequent_char
+        self.assertEqual(most_frequent_char("zzzz"), ("z", 4))
+
+    def test_whitespace_included(self):
+        from text_utils import most_frequent_char
+        # Two spaces and one 'a' => space should win
+        self.assertEqual(most_frequent_char("  a"), (" ", 2))
+
+    def test_punctuation_included(self):
+        from text_utils import most_frequent_char
+        self.assertEqual(most_frequent_char("!!?!"), ("!", 3))
+
+    def test_unicode_handling(self):
+        from text_utils import most_frequent_char
+        self.assertEqual(most_frequent_char("😀😃😃😀😀"), ("😀", 3))
+
+    def test_tie_breaker_earliest_first_occurrence(self):
+        from text_utils import most_frequent_char
+        # 'a' and 'b' both occur twice; 'a' first appears at index 0 in "abba"
+        self.assertEqual(most_frequent_char("abba"), ("a", 2))
+        # In "baba", both occur twice; 'b' first appears at index 0
+        self.assertEqual(most_frequent_char("baba"), ("b", 2))
+
+    def test_case_sensitive(self):
+        from text_utils import most_frequent_char
+        # 'A' (2) vs 'a' (1)
+        self.assertEqual(most_frequent_char("A aA"), ("A", 2))
+
+    def test_empty_input(self):
+        from text_utils import most_frequent_char
+        self.assertEqual(most_frequent_char(""), ("", 0))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/text_utils.py
+++ b/text_utils.py
@@ -4,9 +4,71 @@ Utility text functions.
 This module currently provides:
 - most_frequent_char: find the most frequent character in a string with
   deterministic tie-breaking.
+- edit_distance: compute the Levenshtein (unit-cost) edit distance between two strings.
 """
-
 from __future__ import annotations
+
+from typing import Tuple
+
+
+def edit_distance(a: str, b: str) -> int:
+    """
+    Compute the Levenshtein edit distance between two strings.
+
+    Definition:
+    - Allowed operations are insertion, deletion, and substitution.
+    - Each operation has a unit cost of 1.
+    - The function is case-sensitive and works with arbitrary Unicode characters.
+
+    Parameters
+    ----------
+    a : str
+        First input string.
+    b : str
+        Second input string.
+
+    Returns
+    -------
+    int
+        The minimal number of single-character edits required to transform
+        string `a` into string `b`.
+
+    Examples
+    --------
+    >>> edit_distance("kitten", "sitting")
+    3
+    >>> edit_distance("", "abc")
+    3
+    >>> edit_distance("abc", "abc")
+    0
+    """
+    # Quick responses for trivial cases
+    if a == b:
+        return 0
+    if not a:
+        return len(b)
+    if not b:
+        return len(a)
+
+    # Use a classic dynamic programming approach with O(min(len(a), len(b))) space
+    # Work on the shorter string horizontally to reduce memory
+    if len(b) < len(a):
+        a, b = b, a
+
+    # prev[j] is the edit distance between a[:i-1] and b[:j]
+    prev = list(range(len(b) + 1))
+    for i, ca in enumerate(a, start=1):
+        curr = [i]
+        for j, cb in enumerate(b, start=1):
+            cost = 0 if ca == cb else 1
+            insertion = curr[j - 1] + 1
+            deletion = prev[j] + 1
+            substitution = prev[j - 1] + cost
+            curr.append(min(insertion, deletion, substitution))
+        prev = curr
+    return prev[-1]
+ 
+
 
 from typing import Tuple
 

--- a/text_utils.py
+++ b/text_utils.py
@@ -1,0 +1,59 @@
+"""
+Utility text functions.
+
+This module currently provides:
+- most_frequent_char: find the most frequent character in a string with
+  deterministic tie-breaking.
+"""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+
+def most_frequent_char(s: str) -> Tuple[str, int]:
+    """
+    Return the most frequent character in the input string and its count.
+
+    Rules:
+    - Case-sensitive: "A" and "a" are distinct.
+    - Count all characters, including whitespace and punctuation.
+    - Tie-breaking: if multiple characters have the same highest frequency,
+      return the one whose first occurrence is earliest in the string.
+    - Empty input: return ("", 0).
+
+    Examples
+    --------
+    >>> most_frequent_char("abca")
+    ('a', 2)
+    >>> most_frequent_char("A aA")
+    ('A', 2)
+    >>> most_frequent_char("")
+    ('', 0)
+    """
+    if not s:
+        return ("", 0)
+
+    counts: dict[str, int] = {}
+    first_index: dict[str, int] = {}
+
+    for idx, ch in enumerate(s):
+        if ch not in counts:
+            counts[ch] = 0
+            first_index[ch] = idx
+        counts[ch] += 1
+
+    # Determine the best character by (count desc, first_index asc)
+    best_char = None
+    best_count = -1
+    best_first_idx = len(s) + 1
+
+    for ch, cnt in counts.items():
+        fi = first_index[ch]
+        if cnt > best_count or (cnt == best_count and fi < best_first_idx):
+            best_char = ch
+            best_count = cnt
+            best_first_idx = fi
+
+    # best_char cannot be None here because s is non-empty
+    return best_char, best_count


### PR DESCRIPTION
This PR adds a new utility function `edit_distance(a: str, b: str) -> int` to compute the Levenshtein (unit-cost) edit distance between two strings.

Key points:
- Implementation uses a classic 2-row dynamic programming approach (O(mn) time, O(min(m, n)) space).
- The function is case-sensitive and works with arbitrary Unicode.
- Comprehensive unit tests in `tests/test_edit_distance.py` cover:
  - Empty vs empty, empty vs non-empty
  - Identical strings
  - Single insertion, deletion, substitution
  - Mixed operations (kitten→sitting=3, flaw→lawn=2)
  - Unicode (emojis, accented characters)
  - Asymmetric lengths

All tests pass locally via Dockerfile.test (`python3 -m unittest discover -s tests`).

Please review and merge.