### PR TITLE
feat: add is_anagram utility with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,15 @@ from edit_distance import levenshtein_distance
 print(levenshtein_distance("kitten", "sitting"))  # 3
 print(levenshtein_distance("flaw", "lawn"))       # 2
 ```
+
+Anagram check example (ignores case, whitespace, and punctuation; keeps alphanumerics):
+```python
+from string_utils import is_anagram
+
+print(is_anagram("listen", "silent"))            # True
+print(is_anagram("Dormitory", "Dirty room!!"))    # True
+print(is_anagram("caf\u00e9", "face"))             # False (diacritic preserved)
+```
 # Repository Overview
 
 This repository contains:

--- a/string_utils.py
+++ b/string_utils.py
@@ -5,6 +5,7 @@ Provides simple helper functions for string operations.
 """
 
 from typing import Any
+from collections import Counter
 
 
 def concat_strings(a: str, b: str) -> str:
@@ -19,3 +20,38 @@ def concat_strings(a: str, b: str) -> str:
     """
 
     return a + b
+
+
+def is_anagram(a: str, b: str) -> bool:
+    """Return True if two strings are anagrams of each other.
+
+    Behavior:
+    - Case-insensitive using Unicode-aware casefolding.
+    - Ignores whitespace and punctuation by considering only alphanumeric characters.
+    - Supports Unicode letters and digits via ``str.isalnum()``.
+
+    Examples:
+        >>> is_anagram("listen", "silent")
+        True
+        >>> is_anagram("Dormitory", "Dirty room!!")
+        True
+        >>> is_anagram("caf\u00e9", "face")
+        False
+
+    Args:
+        a: First input string.
+        b: Second input string.
+
+    Returns:
+        True if ``a`` and ``b`` are anagrams under the normalization rules; otherwise False.
+    """
+
+    def _normalize(s: str) -> str:
+        # Unicode-aware normalization: casefold and keep only alphanumeric characters
+        return "".join(ch for ch in s.casefold() if ch.isalnum())
+
+    na = _normalize(a)
+    nb = _normalize(b)
+    if len(na) != len(nb):
+        return False
+    return Counter(na) == Counter(nb)

--- a/tests/test_is_anagram.py
+++ b/tests/test_is_anagram.py
@@ -1,0 +1,43 @@
+import unittest
+
+from string_utils import is_anagram
+
+
+class TestIsAnagram(unittest.TestCase):
+    def test_basic_true_cases(self):
+        self.assertTrue(is_anagram("listen", "silent"))
+        self.assertTrue(is_anagram("evil", "vile"))
+        self.assertTrue(is_anagram("the eyes", "they see"))
+
+    def test_case_and_whitespace_ignored(self):
+        self.assertTrue(is_anagram("Dormitory", "Dirty room!!"))
+        self.assertTrue(is_anagram("Conversation", "Voices rant on"))
+
+    def test_numbers_supported(self):
+        self.assertTrue(is_anagram("123", "321"))
+        self.assertFalse(is_anagram("1123", "321"))
+
+    def test_unicode_letters(self):
+        # Unicode-aware: diacritics are preserved under casefold; not equivalent to ASCII 'e'
+        self.assertFalse(is_anagram("caf\u00e9", "face"))
+        # But rearrangements of the same Unicode letters should match
+        self.assertTrue(is_anagram("b\u00e0", "\u00e0b"))
+
+    def test_cyrillic(self):
+        # "сон" and "нос" are anagrams in Cyrillic when normalized
+        self.assertTrue(is_anagram("Сон", "Нос"))
+
+    def test_different_lengths(self):
+        self.assertFalse(is_anagram("ab", "abc"))
+        self.assertFalse(is_anagram("abc", "ab"))
+
+    def test_negative_cases(self):
+        self.assertFalse(is_anagram("rat", "car"))
+
+    def test_only_non_alphanumerics(self):
+        # After normalization both become empty; treat as anagrams
+        self.assertTrue(is_anagram("!!!", "   "))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR adds a new string utility function `is_anagram(a: str, b: str) -> bool` and comprehensive unit tests.

Highlights:
- Implemented `is_anagram` in `string_utils.py`:
  - Unicode-aware case-insensitive comparison using `str.casefold()`
  - Considers only alphanumeric characters (ignores whitespace/punctuation) using `str.isalnum()`
  - Efficient comparison via `collections.Counter`
- Added tests in `tests/test_is_anagram.py` covering:
  - Typical true/false cases
  - Case and whitespace insensitivity
  - Numeric strings
  - Unicode and Cyrillic examples
  - Differing lengths and negative cases
  - Only-non-alphanumeric inputs (treated as anagrams)
- Updated README with usage examples for `is_anagram`.

All tests pass via Docker (`Dockerfile.test`).