### PR TITLE
test: expand coverage for edit distance, palindrome, and concat invalid inputs

### DIFF
--- a/tests/test_concat_strings_invalid_types.py
+++ b/tests/test_concat_strings_invalid_types.py
@@ -1,0 +1,15 @@
+import unittest
+
+from string_utils import concat_strings
+
+
+class TestConcatStringsInvalidTypes(unittest.TestCase):
+    def test_type_error_on_non_string(self):
+        with self.assertRaises(TypeError):
+            _ = concat_strings("a", 1)  # type: ignore[arg-type]
+        with self.assertRaises(TypeError):
+            _ = concat_strings(2, "b")  # type: ignore[arg-type]
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_edit_distance_additional.py
+++ b/tests/test_edit_distance_additional.py
@@ -1,0 +1,35 @@
+import unittest
+
+from edit_distance import levenshtein_distance
+
+
+class TestLevenshteinDistanceAdditional(unittest.TestCase):
+    def test_commutativity(self):
+        pairs = [
+            ("abc", "yabd"),
+            ("kitten", "sitting"),
+            ("", "longer"),
+            ("abcd", "abxcd"),
+        ]
+        for a, b in pairs:
+            with self.subTest(a=a, b=b):
+                self.assertEqual(levenshtein_distance(a, b), levenshtein_distance(b, a))
+
+    def test_repeat_characters_all_substitutions(self):
+        self.assertEqual(levenshtein_distance("aaaa", "bbbb"), 4)
+
+    def test_single_middle_change_long_string(self):
+        a = "a" * 1000
+        # Change one middle character
+        b = a[:500] + "b" + a[501:]
+        self.assertEqual(levenshtein_distance(a, b), 1)
+
+    def test_unicode_emoji(self):
+        # Different single-codepoint emoji should count as one substitution
+        self.assertEqual(levenshtein_distance("😀", "😃"), 1)
+        # One differing emoji among two
+        self.assertEqual(levenshtein_distance("😀😀", "😀😃"), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_palindrome_check_additional.py
+++ b/tests/test_palindrome_check_additional.py
@@ -1,0 +1,24 @@
+import unittest
+
+from palindrome_check import is_palindrome
+
+
+class TestPalindromeCheckAdditional(unittest.TestCase):
+    def test_numeric_palindromes(self):
+        self.assertTrue(is_palindrome("12321"))
+        self.assertFalse(is_palindrome("123210"))
+
+    def test_phrase_variation(self):
+        self.assertTrue(is_palindrome("No lemon, no melon"))
+
+    def test_unicode_accents_filtered(self):
+        # Current implementation filters non-ASCII letters; "réer" -> "rer"
+        self.assertTrue(is_palindrome("réer"))
+
+    def test_only_non_alnum(self):
+        # Normalizes to empty string -> palindrome
+        self.assertTrue(is_palindrome("!!!"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR increases test coverage without changing implementation.

Added:
- tests/test_edit_distance_additional.py
  - Commutativity property
  - Repeated-character substitutions
  - Long string with single middle change
  - Unicode emoji cases

- tests/test_palindrome_check_additional.py
  - Numeric palindromes and near-misses
  - Phrase variant ("No lemon, no melon")
  - Unicode with accents filtered per current implementation
  - Only non-alphanumeric chars normalize to palindrome

- tests/test_concat_strings_invalid_types.py
  - TypeError expectations for non-string inputs

All tests pass locally via Dockerfile.test (unittest discover): 22 tests, all OK.

No production code changes in this PR.